### PR TITLE
Auth routes

### DIFF
--- a/com/truckmuncher/api/auth.proto
+++ b/com/truckmuncher/api/auth.proto
@@ -26,7 +26,7 @@ message AuthResponse {
     /**
      * Uniquely identifies the logged in user.
      */
-    required string id = 1;
+    required string userId = 1;
     /**
      * The Twitter or Facebook username.
      */


### PR DESCRIPTION
Not quite sure about the names on these, but the fields and comments are there. Definitely open to alternative names for the messages.

Once these get merged Android and iOS will have to use them for sign in/sign out. Everyone on the mobile teams please take note of this.

Web team: only change for you is a route change and its no longer a GET/DELETE. Changing to POSTs to be consistent with the rest of the API. This will go into effect the same time that session tokens get deployed (I hope).

@maconsuckow @atscott @moorea @nockertsb @MariusVolkhart 
