### PR TITLE
Proto file for GCM

### DIFF
--- a/com/truckmuncher/api/gcm.proto
+++ b/com/truckmuncher/api/gcm.proto
@@ -1,0 +1,20 @@
+package com.truckmuncher.api.gcm;
+
+/**
+ * The GcmService is used to register Android devices for push messages.
+ */
+service GcmService {
+
+    rpc registerForGcm (GcmRegistrationRequest) returns (GcmRegistrationResponse);
+}
+
+message GcmRegistrationRequest {
+    /**
+     * Unique identifier for the installation
+     */
+    required string installationId = 1;
+    optional string gcmRegistrationId = 2;
+}
+
+message GcmRegistrationResponse {
+}


### PR DESCRIPTION
Allows Android devices to register for GCM. I don't know how Apple's mechanism works, but that's something that I'd like to figure out before finalizing this.

@nockertsb @moorea @jault3 please review
