### PR TITLE
Duration on reportServingMode

### DIFF
--- a/com/truckmuncher/api/trucks.proto
+++ b/com/truckmuncher/api/trucks.proto
@@ -39,7 +39,8 @@ service TruckService {
     /**
      * Report serving mode status for a truck in a location
      *
-     * This call requires the user to be logged in
+     * This call requires the user to be logged in.
+     * When duration is provided by a vendor (the owner of the truck), it indicates how long the vendor will be at the location.
      */
     rpc reportServingMode (ServingModeRequest) returns (ServingModeResponse);
 
@@ -210,6 +211,14 @@ message ServingModeRequest {
      * Value in the range [-180, 180]
      */
     optional double truckLongitude = 4;
+    /**
+     * Value between 0 and 8
+     */ 
+    optional int32 durationHours = 5;
+    /**
+     * Value between 0 and 60
+     */
+    optional int32 durationMinutes = 6;
 }
 
 message ServingModeResponse {

--- a/com/truckmuncher/api/trucks.proto
+++ b/com/truckmuncher/api/trucks.proto
@@ -212,13 +212,9 @@ message ServingModeRequest {
      */
     optional double truckLongitude = 4;
     /**
-     * Value between 0 and 8
-     */ 
-    optional int32 durationHours = 5;
-    /**
-     * Value between 0 and 60
+     * Value between 0 and 720 (maximum 12 hours)
      */
-    optional int32 durationMinutes = 6;
+    optional int32 durationMinutes = 5;
 }
 
 message ServingModeResponse {


### PR DESCRIPTION
Allow vendors to provide a duration for being at a location. If a food truck is reporting their location, I actually DO trust that they have a pretty good idea of how long they are going to be there. I DON'T trust them to remember to report themselves as not serving when the leave. The website will make these fields required because there is no geofencing option. Mobile clients might want to do geofencing, but maybe requiring the duration would be a solution we can all agree on instead. 

The API should fill in a default duration if not provided. 